### PR TITLE
Utils for iterator-like types (array & lists)

### DIFF
--- a/contracts/mal_like_tay.sol
+++ b/contracts/mal_like_tay.sol
@@ -1042,6 +1042,15 @@ object "Taylor" {
                 shl(1, bodylen)
             )
         }
+        // arity: 1 + number of args
+        function buildApplySig(arity) -> signature {
+            arity := add(arity, 1)
+            // signature :=  '1' * bit4 arity * bit26 id * 0
+            signature := add(
+                add(exp(2, 31), shl(27, arity)),
+                shl(1, 32)
+            )
+        }
 
         // Type list (not function)
         // TODO type

--- a/contracts/mal_like_tay.sol
+++ b/contracts/mal_like_tay.sol
@@ -453,6 +453,21 @@ object "Taylor" {
                 result_ptr := allocate(4)
                 mslicestore(result_ptr, buildBoolSig(answ), 4)
             }
+            case 0x88000068 {
+                let answ := _list_q(mload(add(arg_ptrs_ptr, 32)))
+                result_ptr := allocate(4)
+                mslicestore(result_ptr, buildBoolSig(answ), 4)
+            }
+            case 0x8800006c {
+                let answ := _array_q(mload(add(arg_ptrs_ptr, 32)))
+                result_ptr := allocate(4)
+                mslicestore(result_ptr, buildBoolSig(answ), 4)
+            }
+            case 0x8800006e {
+                let answ := _sequential_q(mload(add(arg_ptrs_ptr, 32)))
+                result_ptr := allocate(4)
+                mslicestore(result_ptr, buildBoolSig(answ), 4)
+            }
             // register!
             case 0x880000c0 {
                 result_ptr := allocate(32)
@@ -1665,6 +1680,21 @@ object "Taylor" {
             if and(eq(isBool(sig), 0), and(isNumber(ptr1), eq(numberSize(sig), 1))) {
                 answ := eq(mslice(add(ptr1, 4), 1), 0)
             }
+        }
+        
+        function _list_q(ptr1) -> answ {
+            answ := isListType(get4b(ptr1))
+        }
+
+        function _array_q(ptr1) -> answ {
+            answ := isArrayType(ptr1)
+        }
+
+        function _sequential_q(ptr1) -> answ {
+            answ := or(
+                isListType(get4b(ptr1)),
+                isArrayType(ptr1)
+            )
         }
 
         function _nth(iter_ptr, index_ptr) -> result_ptr {

--- a/contracts/mal_like_tay.sol
+++ b/contracts/mal_like_tay.sol
@@ -1844,6 +1844,9 @@ object "Taylor" {
 
         function _length(item_ptr) -> result_ptr {
             let vallen := getValueLength(item_ptr)
+            if _sequential_q(item_ptr) {
+                vallen := iterTypeSize(item_ptr)
+            }
             result_ptr := allocate(8)
             mslicestore(result_ptr, buildUintSig(4), 4)
             mslicestore(add(result_ptr, 4), vallen, 4)

--- a/contracts/mal_like_tay.sol
+++ b/contracts/mal_like_tay.sol
@@ -1144,6 +1144,10 @@ object "Taylor" {
             
             // lambda_ptr can be a signature or a lambda pointer
             let lambda_body_ptr := mload(add(arg_ptrs, 32))
+
+            if isLambda(get4b(lambda_body_ptr)) {
+                lambda_body_ptr := add(lambda_body_ptr, 4)
+            }
             
             // TODO: if signature -> call eval
 

--- a/contracts/mal_like_tay.sol
+++ b/contracts/mal_like_tay.sol
@@ -565,6 +565,12 @@ object "Taylor" {
                 let ptr2 := mload(add(arg_ptrs_ptr, 64))
                 result_ptr := _join(ptr1, ptr2)
             }
+            case 0x98000132 {
+                let start_ptr := mload(add(arg_ptrs_ptr, 32))
+                let stop_ptr := mload(add(arg_ptrs_ptr, 64))
+                let step_ptr := mload(add(arg_ptrs_ptr, 96))
+                result_ptr := _range(start_ptr, stop_ptr, step_ptr)
+            }
 
             default {
                 let isthis := 0
@@ -1796,6 +1802,23 @@ object "Taylor" {
             mmultistore(current_ptr, add(ptr1, siglen1), vallen1)
             current_ptr := add(current_ptr, vallen1)
             mmultistore(current_ptr, add(ptr2, siglen2), vallen2)
+        }
+
+        function _range(start_ptr, stop_ptr, step_ptr) -> result_ptr {
+            let start := extractValue(start_ptr)
+            let stopp := extractValue(stop_ptr)
+            let step := extractValue(step_ptr)
+            // let arity := div(add(sub(stopp, start), 1), step)
+            let arity := add(div(sub(stopp, start), step), 1)
+
+            result_ptr := allocate(add(8, mul(4, arity)))
+            mslicestore(result_ptr, buildArraySig(arity), 4)
+            mslicestore(add(result_ptr, 4), buildUintSig(4), 4)
+            let current_ptr := add(result_ptr, 8)
+            for { let i := start } lt(i, add(stopp, 1)) { i := add(i, step) } {
+                mslicestore(current_ptr, i, 4)
+                current_ptr := add(current_ptr, 4)
+            }
         }
 
         function _save(ptrs) -> result_ptr {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "jest": "^24",
     "solc": "^0.6.10",
-    "webpack": "^4.43.0",
+    "webpack": "4.42.0",
     "webpack-cli": "^3.3.12"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -344,7 +344,6 @@ const ast2h = (ast, parent=null, unkownMap={}, defenv={}) => {
             const elem = ast[1][i];
             unkownMap[elem.value] = unknown(Object.keys(unkownMap).length);
             definitions += unkownMap[elem.value];
-            const encodedvalue = ast2h(ast[1][i+1], ast, unkownMap, defenv);
 
             if (
                 ast[1][i+1]
@@ -359,6 +358,7 @@ const ast2h = (ast, parent=null, unkownMap={}, defenv={}) => {
                 }
             }
             
+            const encodedvalue = ast2h(ast[1][i+1], ast, unkownMap, defenv);
             definitions += encodedvalue;
         }
         const execution = ast2h([ast[2]], ast, unkownMap, defenv);

--- a/src/index.js
+++ b/src/index.js
@@ -341,7 +341,7 @@ const ast2h = (ast, parent=null, unkownMap={}, defenv={}) => {
         for (let i = 0; i < arity; i += 2) {
             const elem = ast[1][i];
             unkownMap[elem.value] = unknown(Object.keys(unkownMap).length);
-            definitions += getbytesid(8) + unkownMap[elem.value];
+            definitions += unkownMap[elem.value];
             const encodedvalue = ast2h([ast[1][i+1]], ast[1], unkownMap, defenv);
             definitions += encodedvalue;
         }

--- a/src/index.js
+++ b/src/index.js
@@ -312,6 +312,8 @@ const decode = data => {
 }
 
 const ast2h = (ast, parent=null, unkownMap={}, defenv={}) => {
+    if (!(ast instanceof Array)) ast = [ast];
+    
     // do not count the function itselt
     const arity = ast.length - 1;
 
@@ -342,7 +344,7 @@ const ast2h = (ast, parent=null, unkownMap={}, defenv={}) => {
             const elem = ast[1][i];
             unkownMap[elem.value] = unknown(Object.keys(unkownMap).length);
             definitions += unkownMap[elem.value];
-            const encodedvalue = ast2h([ast[1][i+1]], ast[1], unkownMap, defenv);
+            const encodedvalue = ast2h(ast[1][i+1], ast, unkownMap, defenv);
             definitions += encodedvalue;
         }
         const execution = ast2h([ast[2]], ast, unkownMap, defenv);

--- a/src/mal_backend.js
+++ b/src/mal_backend.js
@@ -76,7 +76,8 @@ modifyEnv('js-eval', (orig_func, str) => {
             } catch(e) {}
 
             return value;
-        }
+        },
+        range: (start, stop, step) => [...Array(stop + 1).keys()].slice(start, stop+1).filter((no, i) => i % step === 0)
     }
     let answ = eval(str.toString());
 
@@ -98,6 +99,8 @@ mal.reps(`
 (def! sload (fn* (key type) (js-eval (str "utils.sload(" key ",'" type "')") )))
 
 (def! array (fn* (& xs) xs ))
+
+(def! range (fn* (start stop step) (js-eval (str "utils.range(" start "," stop "," step ")" )) ))
 `)
 
 /* EVM */

--- a/src/mal_backend.js
+++ b/src/mal_backend.js
@@ -96,6 +96,8 @@ mal.reps(`
 (def! store! (fn* (key value) (js-eval (str "utils.store(" key ",'" value "')") )))
 
 (def! sload (fn* (key type) (js-eval (str "utils.sload(" key ",'" type "')") )))
+
+(def! array (fn* (& xs) xs ))
 `)
 
 /* EVM */

--- a/src/native.js
+++ b/src/native.js
@@ -161,6 +161,7 @@ const _nativeEnv = {
     push:      { mutable: false, arity: 2 },
     slice:     { mutable: false, arity: 2 },
     length:    { mutable: false, arity: 1},
+    join:     { mutable: false, arity: 2 },
 
     // TODO: curry
     // TODO: pay

--- a/src/native.js
+++ b/src/native.js
@@ -158,6 +158,9 @@ const _nativeEnv = {
     'update!': { mutable: false, arity: 3 },
     defstruct: { mutable: false, arity: 1 },
     'refs-struct': { mutable: false, arity: 1 },
+    push:      { mutable: false, arity: 2 },
+    slice:     { mutable: false, arity: 2 },
+    length:    { mutable: false, arity: 1},
 
     // TODO: curry
     // TODO: pay

--- a/src/native.js
+++ b/src/native.js
@@ -161,7 +161,8 @@ const _nativeEnv = {
     push:      { mutable: false, arity: 2 },
     slice:     { mutable: false, arity: 2 },
     length:    { mutable: false, arity: 1},
-    join:     { mutable: false, arity: 2 },
+    join:      { mutable: false, arity: 2 },
+    range:     { mutable: false, arity: 3 },
 
     // TODO: curry
     // TODO: pay

--- a/src/native.js
+++ b/src/native.js
@@ -55,10 +55,11 @@ const _nativeEnv = {
     cons:         { mutable: false, arity: 2, notimp: true },  // prepend item to list
     concat2:      { mutable: false, arity: null, notimp: true },  // concats lists
     'nil?':       { mutable: false, arity: 1 },
-    'list?':      { mutable: false, arity: 1, notimp: true },
+    'list?':      { mutable: false, arity: 1 },
     vector:       { mutable: false, arity: null, notimp: true },
-    'vector?':    { mutable: false, arity: 1, notimp: true },
-    'sequential?':{ mutable: false, arity: 1, notimp: true },
+    // 'vector?':    { mutable: false, arity: 1, notimp: true },
+    'array?':     { mutable: false, arity: 1 },
+    'sequential?':{ mutable: false, arity: 1 },
     'hash-map':   { mutable: false, arity: null, notimp: true },
     'map?':       { mutable: false, arity: 1, notimp: true },
     assoc:        { mutable: false, arity: null, notimp: true },

--- a/tests/maltay.test.js
+++ b/tests/maltay.test.js
@@ -606,6 +606,63 @@ describe.each([
         resp = await instance.call('(nil? "0x22")');
         expect(resp).toBe(false);
     });
+
+    it('test list?', async function() {
+        let resp;
+    
+        resp = await instance.call('(list? (list))');
+        expect(resp).toBe(true);
+
+        resp = await instance.call('(list? (list 1 5))');
+        expect(resp).toBe(true);
+
+        resp = await instance.call('(list? 4)');
+        expect(resp).toBe(false);
+
+        // TODO on js side there if no way now to differentiate between
+        // a list and array if the internal types are the same
+        if (backendname === 'chain') {
+            resp = await instance.call('(list? (array 1 5))');
+            expect(resp).toBe(false);
+        }
+    });
+
+    if (backendname === 'chain') {
+        it('test array?', async function() {
+            let resp;
+
+            resp = await instance.call('(array? (array))');
+            expect(resp).toBe(true);
+
+            resp = await instance.call('(array? (array 1 5))');
+            expect(resp).toBe(true);
+
+            resp = await instance.call('(array? 4)');
+            expect(resp).toBe(false);
+
+            resp = await instance.call('(array? (list 1 5))');
+            expect(resp).toBe(false);
+        });
+    }
+
+    it('test sequential?', async function() {
+        let resp;
+    
+        resp = await instance.call('(sequential? (list))');
+        expect(resp).toBe(true);
+
+        resp = await instance.call('(sequential? (array))');
+        expect(resp).toBe(true);
+
+        resp = await instance.call('(sequential? (list 1 5))');
+        expect(resp).toBe(true);
+
+        resp = await instance.call('(sequential? (array 1 5))');
+        expect(resp).toBe(true);
+
+        resp = await instance.call('(sequential? 4)');
+        expect(resp).toBe(false);
+    });
     
     it('test iterator functions', async function() {
         let resp;

--- a/tests/maltay.test.js
+++ b/tests/maltay.test.js
@@ -650,6 +650,22 @@ describe.each([
         expect(resp).toBe(9);
     });
 
+    it('test let* & lambda', async function() {
+        resp = await instance.call(`(let* (
+                somelambda (fn* (a) (add a 1))
+            )
+            (somelambda 3)
+        )`);
+        expect(resp).toBe(4);
+
+        resp = await instance.call(`(let* (
+            somelambda (fn* (a) (add a 1))
+            )
+            (map somelambda (array 3 4))
+        )`);
+        expect(resp).toEqual([4, 5]);
+    });
+
     it('test use stored fn 1', async function () {
         let resp;
         let name = 'func1'

--- a/tests/maltay.test.js
+++ b/tests/maltay.test.js
@@ -701,6 +701,9 @@ describe.each([
 
         resp = await instance.call('(map iszero (list 5 0 2))');
         expect(resp).toEqual([0, 1, 0]);
+
+        resp = await instance.call('(map iszero (array 5 0 2))');
+        expect(resp).toEqual([0, 1, 0]);
     
         await instance.sendAndWait('(def! myfunc (fn* (a) (mul (add a 1) 3)))');
         
@@ -710,6 +713,12 @@ describe.each([
         resp = await instance.call(`(map
             (fn* (a) (mul (add a 1) 3))
             (list 5 8 2)
+        )`);
+        expect(resp).toEqual([18, 27, 9]);
+
+        resp = await instance.call(`(map
+            (fn* (a) (mul (add a 1) 3))
+            (array 5 8 2)
         )`);
         expect(resp).toEqual([18, 27, 9]);
 
@@ -724,6 +733,13 @@ describe.each([
                 somelambda (fn* (a) (mul (add a 1) 3))
             )
             (map somelambda (list 5 8 2) )
+        )`);
+        expect(resp).toEqual([18, 27, 9]);
+
+        resp = await instance.call(`(let* (
+                somelambda (fn* (a) (mul (add a 1) 3))
+            )
+            (map somelambda (array 5 8 2) )
         )`);
         expect(resp).toEqual([18, 27, 9]);
 

--- a/tests/maltay.test.js
+++ b/tests/maltay.test.js
@@ -1129,6 +1129,46 @@ describe.each([
     });
 });
 
+it('test push', async function() {
+    let resp;
+    resp = await MalTay.call(`(push (array 4 5 6) 20)`);
+    expect(resp).toEqual([4, 5, 6, 20]);
+
+    resp = await MalTay.call(`(push (array (array 4 5 6) (array 7 8 9) ) (array 10 11 12) 1)`);
+    expect(resp).toEqual([[4, 5, 6], [7, 8, 9], [10, 11, 12]]);
+
+    resp = await MalTay.call(`(push (array "0x1122" "0x3344" "0x5566") "0x7788")`);
+    expect(resp).toEqual(['0x1122', '0x3344', '0x5566', '0x7788']);
+
+    resp = await MalTay.call(`(push (array) "0x7788")`);
+    expect(resp).toEqual(['0x7788']);
+
+    resp = await MalTay.call(`(push (array) 20)`);
+    expect(resp).toEqual([20]);
+});
+
+it('test slice', async function() {
+    let resp;
+
+    resp = await MalTay.call(`(slice "0x11223344556677" 3)`);
+    expect(resp).toEqual(['0x112233', '0x44556677']);
+
+    resp = await MalTay.call(`(slice "0x1122334455" 5)`);
+    expect(resp).toEqual(['0x1122334455', '0x']);
+
+    resp = await MalTay.call(`(slice "0x" 5)`);
+    expect(resp).toEqual(['0x', '0x']);
+});
+
+it('test length', async function() {
+    let resp;
+
+    resp = await MalTay.call(`(length "0x11223344556677")`);
+    expect(resp).toBe(7);
+
+    // TODO same function for array length (diff behaviour per type);
+});
+
 describe('test mapping', function () {
     it('value: simple type', async function() {
         let resp;

--- a/tests/maltay.test.js
+++ b/tests/maltay.test.js
@@ -860,6 +860,26 @@ describe.each([
         expect(resp).toBe(21);
     });
 
+    it('test recursive lambda', async function () {
+        let resp;
+
+        resp = await instance.call(`(let* 
+            (recursivefn 
+                (fn* (n) (if (gt n 5) n (recursivefn (add n 1)) ) )
+            )
+            (recursivefn 2)
+        )`);
+        expect(resp).toBe(6);
+
+        resp = await instance.call(`(let* 
+            (localfibo 
+                (fn* (n) (if (or (eq n 1) (eq n 2)) 1 (add(localfibo (sub n 1)) (localfibo (sub n 2)) ) ))
+            )
+            (localfibo 8)
+        )`);
+        expect(resp).toBe(21);
+    });
+
     it('test byte-like', async function() {
         resp = await instance.call('(list "0x2233" "hello" "0x44556677" "someword")');
         expect(resp).toEqual(['0x2233', 'hello', '0x44556677', 'someword']);

--- a/tests/maltay.test.js
+++ b/tests/maltay.test.js
@@ -1175,6 +1175,25 @@ it('test length', async function() {
     // TODO same function for array length (diff behaviour per type);
 });
 
+
+it('test join', async function() {
+    let resp;
+    resp = await MalTay.call(`(join "0x112233" "0x445566"))`);
+    expect(resp).toBe('0x112233445566');
+
+    resp = await MalTay.call(`(join "0x112233" 8))`);
+    expect(resp).toBe('0x11223300000008');
+
+    resp = await MalTay.call(`(join "hello" "yello"))`);
+    expect(resp).toBe('helloyello');
+
+    resp = await MalTay.call(`(join "0x112233" "hello"))`);
+    expect(resp).toBe('0x1122330000000000000000000000000000000000000000000000680065006c006c006f');
+
+    resp = await MalTay.call(`(join "0x" "0x445566"))`);
+    expect(resp).toBe('0x445566');
+});
+
 describe('test mapping', function () {
     it('value: simple type', async function() {
         let resp;

--- a/tests/maltay.test.js
+++ b/tests/maltay.test.js
@@ -708,6 +708,12 @@ describe.each([
         resp = await instance.call('(map myfunc (list 5 8 2))');
         expect(resp).toEqual([18, 27, 9]);
 
+        resp = await instance.call(`(map
+            (fn* (a) (mul (add a 1) 3))
+            (list 5 8 2)
+        )`);
+        expect(resp).toEqual([18, 27, 9]);
+
         if (backendname === 'chain') {
             resp = await instance.getFns();
             expect(resp.length).toBe(3);
@@ -746,6 +752,13 @@ describe.each([
         expect(resp).toBe(15);
 
         resp = await instance.call('(reduce myfunc2 (array 5 8 2) 0)');
+        expect(resp).toBe(15);
+
+        resp = await instance.call(`(reduce
+            (fn* (a b) (add a b))
+            (list 5 8 2)
+            0
+        )`);
         expect(resp).toBe(15);
     });
 

--- a/tests/maltay.test.js
+++ b/tests/maltay.test.js
@@ -786,6 +786,27 @@ describe.each([
         expect(resp).toEqual(['0x2233', 'hello', '0x44556677', 'someword']);
     });
 
+    it('test range', async function() {
+        resp = await instance.call('(range 1 5 1)');
+        expect(resp).toEqual([1, 2, 3, 4, 5]);
+
+        resp = await instance.call('(range 3 19 3)');
+        expect(resp).toEqual([3, 6, 9, 12, 15, 18]);
+
+        resp = await instance.call('(range 89 168 20)');
+        expect(resp).toEqual([89, 109, 129, 149]);
+
+        resp = await instance.call('(range 1 1 1)');
+        expect(resp).toEqual([1]);
+
+        resp = await instance.call('(range 0 0 1)');
+        expect(resp).toEqual([0]);
+
+        // TODO: support negative step
+        // resp = await instance.call('(range 5 1 -1)');
+        // expect(resp).toEqual([5, 4, 3, 2, 1]);
+    });
+
     test(`add`, async () => {
         resp = await instance.call('(add 9 3)');
         expect(resp).toBe(12);

--- a/tests/maltay.test.js
+++ b/tests/maltay.test.js
@@ -608,16 +608,28 @@ describe.each([
         expect(resp).toBe(false);
     });
     
-    it('test list functions', async function() {
+    it('test iterator functions', async function() {
         let resp;
         resp = await instance.call('(first (list 5 3 7))');
         expect(resp).toBe(5);
     
-        resp = await instance.call('(rest (list 5 3 7))');
-        expect(resp).toEqual([3, 7]);
-    
         resp = await instance.call('(nth (list 5 3 7) 2)');
         expect(resp).toBe(7);
+
+        resp = await instance.call('(rest (list 5 3 7))');
+        expect(resp).toEqual([3, 7]);
+
+        resp = await instance.call('(first (array 5 3 7))');
+        expect(resp).toBe(5);
+    
+        resp = await instance.call('(nth (array 5 3 7) 2)');
+        expect(resp).toBe(7);
+
+        resp = await instance.call('(nth (array (array 5 3 7) (array 8 4 2) (array 9 11 12)) 1)');
+        expect(resp).toEqual([8, 4, 2]);
+
+        resp = await instance.call('(rest (array 5 3 7))');
+        expect(resp).toEqual([3, 7]);
     });
 
     it('test let* & nested scopes', async function() {

--- a/tests/maltay.test.js
+++ b/tests/maltay.test.js
@@ -730,6 +730,9 @@ describe.each([
     
         resp = await instance.call('(reduce sub (list 45 8 2) 100)');
         expect(resp).toBe(45);
+
+        resp = await instance.call('(reduce sub (array 45 8 2) 100)');
+        expect(resp).toBe(45);
         
         await instance.sendAndWait('(def! myfunc2 (fn* (a b) (add a b)) )');
     
@@ -740,6 +743,9 @@ describe.each([
         expect(resp).toBe(5);
       
         resp = await instance.call('(reduce myfunc2 (list 5 8 2) 0)');
+        expect(resp).toBe(15);
+
+        resp = await instance.call('(reduce myfunc2 (array 5 8 2) 0)');
         expect(resp).toBe(15);
     });
 


### PR DESCRIPTION
- Arrays can also use `first`, `nth`, `rest` (not only lists)
- `push`, `slice`, `length`
- fix empty array `(array)`
- `reduce` also works on arrays now
- `join` -> bytelike; join bytes, strings, bytes & numbers, bytes & strings
- `bytesToArray`, `arrayToBytes` (composed functions)